### PR TITLE
Typos niall

### DIFF
--- a/app/group-board.html
+++ b/app/group-board.html
@@ -75,7 +75,7 @@
         <section id="board-members" class="board-members">
             <div class="container">
                 <h2>Board of Directors</h2>
-                <h4>Independant & Rigorous Oversight</h4>
+                <h4>Independent & Rigorous Oversight</h4>
                 <hr>
                 <div class="row">
                     <div class="col-md-10">
@@ -225,8 +225,8 @@
                 </div>
                 <div class="row">
                     <div class="col-md-10">
-                        <div class="col-md-5">
-                            <h4>Siobhan Lohan - Independant Non Executive</h4>
+    e                 <div class="col-md-5">
+                            <h4>Siobhan Lohan - Independent Non Executive</h4>
                             <img src="./images/board/Siobhain Madden CLO.png">
                         </div>
                         <div class="col-md-7">
@@ -255,7 +255,7 @@
                 <div class="row">
                     <div class="col-md-10">
                         <div class="col-md-5">
-                            <h4>John Caslin - Independant Non Executive</h4>
+                            <h4>John Caslin - Independent Non Executive</h4>
                             <img src="./images/board/John Caslin CRO.jpg">
                         </div>
                         <div class="col-md-7">
@@ -295,7 +295,7 @@
                 <div class="row">
                     <div class="col-md-10">
                         <div class="col-md-5">
-                            <h4>David Morris - Independant Non Executive</h4>
+                            <h4>David Morris - Independent Non Executive</h4>
                             <img src="./images/board/Dave Morris.jpg">
                         </div>
                         <div class="col-md-7">

--- a/app/group-board.html
+++ b/app/group-board.html
@@ -97,14 +97,14 @@
                                 transactions including airline acquisitions. ASL
                                 now has an annual turnover of
                                 a billion U.S. dollars and operates a fleet of
-                                circa 135 aircraft globally
+                                circa 135 aircraft globally.
                                 <br><br>
                                 Together with its aviation support companies and
                                 leasing activities, the ASL fleet consists of
                                 varying
                                 aircraft ranging from B747/B737/B757 series,
                                 A300, A330, Hercules
-                                to ATR types which operate worldwide
+                                to ATR types which operate worldwide.
                                 <br>A dual citizen of Ireland and South Africa
                                 Hugh
                                 began his aviation career in 1972 undergoing
@@ -123,7 +123,7 @@
                                 He has since amassed over 30 years’ experience
                                 as a senior aviation business leader
                                 Hugh still enjoys flying and continues to hold a
-                                Commercial Pilot License</p>
+                                Commercial Pilot License.</p>
                         </div>
                     </div>
                 </div>
@@ -144,7 +144,7 @@
                                 of Brian’s were AerCap,
                                 Avolon, Goshawk,
                                 International Airlines Group
-                                (IAG) and Ryanair
+                                (IAG) and Ryanair.
                                 <br><br>
                                 Brian has 20 years experience in the aviation
                                 industry
@@ -156,17 +156,17 @@
                                 aircraft lessors and airlines
                                 Former Managing Director of an Irish based dry
                                 bulk ship leasing and port operating business
-                                with hubs in the Netherlands and France
+                                with hubs in the Netherlands and France.
                                 <br><br>
                                 Brian is a fellow of the Institute of Chartered
                                 Accountants in Ireland and a Member of the
-                                Institute of Engineers in Ireland
+                                Institute of Engineers in Ireland.
                                 <br><br>Brian has a BEng (Hons) Degree in
                                 Chemical
                                 Engineering (Queens University Belfast) an MSC
                                 in Computer Science (University of Edinburgh)
                                 and a Diploma in Corporate Finance (Chartered
-                                Accountants Ireland)
+                                Accountants Ireland).
                             </p>
                         </div>
                     </div>
@@ -183,11 +183,11 @@
                                 industry over the last 31 years with
                                 a primary focus on productivity,
                                 customer experience, operational
-                                excellence and people
+                                excellence and people.
                                 <br><br>Brian has worked closely at board
                                 and executive levels of full-service
                                 airlines, regional airlines, MRO’s,
-                                airports and aircraft lessors
+                                airports and aircraft lessors.
                                 <br><br> A founding investor in Regional Express
                                 Airlines (ASX: REX)
                                 Australia’s largest regional airline with 57
@@ -197,7 +197,7 @@
                                 Hazelton Airlines from Ansett Australia (in
                                 administration). Brian was a Non-Executive
                                 Director prior
-                                to its IPO
+                                to its IPO.
                                 <br><br>Brian has been actively developing a
                                 presence in the
                                 aircraft trading and leasing sectors with a
@@ -206,7 +206,7 @@
                                 in Africa and
                                 a number of aircraft acquisitions on foot with
                                 lessors and
-                                airlines
+                                airlines.
                                 <br><br>Has developed and led a successful
                                 aviation advisory and
                                 consulting business operating from their offices
@@ -219,7 +219,7 @@
                                 Limerick) and
                                 a Diploma in Aircraft Leasing & Financing (Law
                                 Society
-                                of Ireland)</p>
+                                of Ireland).</p>
                         </div>
                     </div>
                 </div>
@@ -233,24 +233,22 @@
                             <p>Siobhan is a Legal and strategic
                                 advisor bringing over 20 years of
                                 aviation and commercial
-                                experience to the team<br>
+                                experience to the team.<br>
                                 Siobhán is a qualified lawyer and
                                 tax consultant, and a member of
-                                the New York Bar<br>
+                                the New York Bar.<br>
                                 Currently non executive director to mobile
                                 transport
                                 companies and financial services companies<br>
                                 Retired senior equity partner in A&L Goodbody,
-                                Ireland’s
-                                leading Aircraft Leasing legal advisory firm<br>
-                                Previous clients include GECAS and Airbus<br>
+                                Ireland’s leading Aircraft Leasing legal advisory firm.<br>
+                                Previous clients include GECAS and Airbus.<br>
                                 General Counsel Ireland for Zurich Insurance
-                                Group<br>
+                                Group.<br>
                                 European Legal Counsel for GATX Aircraft Leasing
-                                Corporation (now MacQuarie Air Finance)<br>
+                                Corporation (now MacQuarie Air Finance).<br>
                                 Founding member and creator of the Unidroit Cape
-                                Town
-                                Convention</p>
+                                Town Convention.</p>
                         </div>
                     </div>
                 </div>
@@ -269,7 +267,7 @@
                                 of Actuaries in Ireland and a
                                 former chairman of the
                                 Society’s Investment &
-                                Finance Committee<br>
+                                Finance Committee.<br>
                                 He has served as a director of iShares plc, an
                                 index
                                 and ETF fund manager; a director of Alder
@@ -309,7 +307,7 @@
                                 Standard Chartered Bank
                                 Aviation Finance, and currently
                                 holds a Non-Executive Director
-                                role with CALC Global Limited
+                                role with CALC Global Limited.
                                 <br><br>
                                 With a career spanning 45 years in aviation Dave
                                 is a
@@ -323,7 +321,7 @@
                                 coaching
                                 personal and professional development in
                                 individuals
-                                and teams
+                                and teams.
                                 <br><br>
                                 Dave also a holds a Diploma in Aviation Leasing
                                 and
@@ -331,7 +329,7 @@
                                 Studies
                                 and is a certified Neuro Linguistic Programming
                                 (NLP)
-                                Practitioner</p>
+                                Practitioner.</p>
                         </div>
                     </div>
                 </div>
@@ -356,7 +354,7 @@
                                 has developed a wide aviation
                                 network across Europe, North
                                 America, Africa, and the Middle
-                                East<br><br>
+                                East.<br><br>
                                 He has established his own
                                 business advisory and consulting
                                 services company, providing
@@ -364,7 +362,7 @@
                                 development and project
                                 management services to airlines,
                                 IT, parts trading and consulting
-                                companies<br><br>
+                                companies.<br><br>
                                 William has an MBA and a Bachelor
                                 of Business degree from the
                                 University of Limerick, and a
@@ -373,7 +371,7 @@
                                 He spent several years on the
                                 Board of The Federation of
                                 Aerospace Enterprises in Ireland
-                                and was Chairman from 2008-2010</p>
+                                and was Chairman from 2008-2010.</p>
                         </div>
                     </div>
                 </div>
@@ -392,7 +390,7 @@
                                 complex COSO risk
                                 frameworks, business growth,
                                 communication, training and
-                                mentoring<br><br>
+                                mentoring.<br><br>
                                 An extremely diversified skill
                                 set coupled with an
                                 extensive international
@@ -404,10 +402,10 @@
                                 director HR OWEN plc and a
                                 director and is recently retired
                                 from the position of treasurer
-                                of Swim Ireland<br><br>
+                                of Swim Ireland.<br><br>
                                 Fellow of the Institute of
                                 Chartered Accountants in
-                                Ireland</p>
+                                Ireland.</p>
                         </div>
                     </div>
                 </div>

--- a/app/index.html
+++ b/app/index.html
@@ -214,7 +214,7 @@
             <img class="small-logo" src="./images/small-logo.png">
             <h4>Asia Australasia</h4>
             <p>India; Asia, Australia; New Zealand & Pacific</p>
-            <p>Office: <a href="#">Signapore</a></p>
+            <p>Office: <a href="#">Singapore</a></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Typos include:

- Singapore is spelt wrong as one of our regional offices so needs to be changed. 
- On the Board of Directors page Independent is spelt as such and not Independant as is currently there.  Can we make the changes at the title of the page and for Siobhan, John, Dave? 
- Also there are a number of full stops obviously missing from the Bio’s for each of the directors. 